### PR TITLE
[TASK] Return type declaration must be compatible with LoggerInterface

### DIFF
--- a/Classes/Logger/DummyLogger.php
+++ b/Classes/Logger/DummyLogger.php
@@ -5,47 +5,47 @@ use Psr\Log\LoggerInterface;
 
 class DummyLogger implements LoggerInterface
 {
-    public function emergency(\Stringable|string $message, array $context = [])
+    public function emergency(\Stringable|string $message, array $context = []): void
     {
         // TODO: Implement emergency() method.
     }
 
-    public function alert(\Stringable|string $message, array $context = [])
+    public function alert(\Stringable|string $message, array $context = []): void
     {
         // TODO: Implement alert() method.
     }
 
-    public function critical(\Stringable|string $message, array $context = [])
+    public function critical(\Stringable|string $message, array $context = []): void
     {
         // TODO: Implement critical() method.
     }
 
-    public function error(\Stringable|string $message, array $context = [])
+    public function error(\Stringable|string $message, array $context = []): void
     {
         // TODO: Implement error() method.
     }
 
-    public function warning(\Stringable|string $message, array $context = [])
+    public function warning(\Stringable|string $message, array $context = []): void
     {
         // TODO: Implement warning() method.
     }
 
-    public function notice(\Stringable|string $message, array $context = [])
+    public function notice(\Stringable|string $message, array $context = []): void
     {
         // TODO: Implement notice() method.
     }
 
-    public function info(\Stringable|string $message, array $context = [])
+    public function info(\Stringable|string $message, array $context = []): void
     {
         // TODO: Implement info() method.
     }
 
-    public function debug(\Stringable|string $message, array $context = [])
+    public function debug(\Stringable|string $message, array $context = []): void
     {
         // TODO: Implement debug() method.
     }
 
-    public function log($level, \Stringable|string $message, array $context = [])
+    public function log($level, \Stringable|string $message, array $context = []): void
     {
         // TODO: Implement log() method.
     }


### PR DESCRIPTION
## Explanation

The return type of `DummyLogger` and `LoggerInterface` must be declared and the same (`void`), to avoid error messages while using the neos `flow` command:

```bash
> Neos\Flow\Composer\InstallerScripts::postUpdateAndInstall
[26-May-2025 05:47:24 UTC] PHP Fatal error:  Declaration of JvMTECH\AIToolkit\Logger\DummyLogger::emergency(Stringable|string $message, array $context = []) must be compatible with Psr\Log\LoggerInterface::emergency(Stringable|string $message, array $context = []): void in /var/www/html/Packages/Application/JvMTECH.AIToolkit/Classes/Logger/DummyLogger.php on line 8

Fatal error: Declaration of JvMTECH\AIToolkit\Logger\DummyLogger::emergency(Stringable|string $message, array $context = []) must be compatible with Psr\Log\LoggerInterface::emergency(Stringable|string $message, array $context = []): void in /var/www/html/Packages/Application/JvMTECH.AIToolkit/Classes/Logger/DummyLogger.php on line 8
```

**Solution**: Use return type `void` as used in the LoggerInterface